### PR TITLE
feat:在插件使用时默认可以不传参数；修复缺少debug依赖

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,20 +1,14 @@
-import { UserConfig } from 'vite'
+import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import { createPlugin, vueDocFiles } from 'vite-plugin-vuedoc'
 
-const config: UserConfig = {
+export default defineConfig({
   plugins: [
-    createPlugin({
-      highlight: {
-        theme: 'one-dark'
-      }
-    }),
+    createPlugin(),
     vue({
       include: [...vueDocFiles]
     }),
     vueJsx()
   ]
-}
-
-export default config
+})

--- a/packages/vite-plugin-vuedoc/src/plugin.ts
+++ b/packages/vite-plugin-vuedoc/src/plugin.ts
@@ -20,7 +20,21 @@ export type VueDocPluginOptions = {
 const cacheDemos: Map<string, DemoBlockType[]> = new Map()
 
 export function createVueDocPlugin(options: Partial<VueDocPluginOptions>) {
-  const { wrapperClass = '', previewClass = '', previewComponent = '', markdownIt, highlight } = options
+  const { wrapperClass, previewClass, previewComponent, markdownIt, highlight } = Object.assign(
+    Object.create(null),
+    {
+      wrapperClass: '',
+      previewClass: '',
+      previewComponent: '',
+      markdownIt: {
+        plugins: []
+      },
+      highlight: {
+        theme: 'one-dark'
+      }
+    },
+    options || {}
+  )
   const { plugins = [] } = markdownIt || {}
   const { theme = 'one-dark' } = highlight || {}
   const _options: VueDocPluginOptions = {


### PR DESCRIPTION
使用环境：
vite-plugin-vuedoc: 3.1.4

发现的问题：

1. 在使用插件时必须传一个参数，否则ts会报错（其实可以不传）
2. 提示缺少debug依赖

解决：
本request修复了这两个问题